### PR TITLE
Remove atty dependency due to it is no longer maintained.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ approx = { version = "0.5", optional = true, default-features = false }
 rug = { version = "1.15", optional = true }
 
 colored = { version = "3.0", optional = true }
-atty = { version = "0.2.14", optional = true }
 clap = { version = "4.0", optional = true, features = ["cargo"] }
 clap_autocomplete = { version = "0.4", optional = true }
 poloto = { version = "19", optional = true, default-features = false }
@@ -81,7 +80,7 @@ generic-impls = ["num-traits"]
 bin = ["clap", "poloto", "regression", "binary_search_rng", "ols"]
 
 # Prettier bin output
-pretty = ["bin", "atty", "colored"]
+pretty = ["bin", "colored"]
 
 # Shell completion output
 completion = ["clap_autocomplete"]

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -608,7 +608,7 @@ fn main() {
     );
 
     #[cfg(feature = "pretty")]
-    let tty = atty::is(atty::Stream::Stdin);
+    let tty = std::io::stdin().is_terminal();
     #[cfg(not(feature = "pretty"))]
     let tty = false;
 


### PR DESCRIPTION
[atty](https://github.com/softprops/atty) is no longer maintained, and the original maintainer has recommended using the equivalent functionality provided by Rust’s standard library via [std::io::IsTerminal](https://doc.rust-lang.org/std/io/trait.IsTerminal.html), introduced in [Rust 1.70.0](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html#isterminal).

Although the immediate impact on std-dev is minimal, it’s beneficial to reduce external dependencies and keep the project as lean as possible.