### PR TITLE
Removing atty due to it is no longer maintained, bump rust-version and simplify method.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ approx = { version = "0.5", optional = true, default-features = false }
 rug = { version = "1.15", optional = true }
 
 colored = { version = "3.0", optional = true }
-atty = { version = "0.2.14", optional = true }
 clap = { version = "4.0", optional = true, features = ["cargo"] }
 clap_autocomplete = { version = "0.4", optional = true }
 poloto = { version = "19", optional = true, default-features = false }
@@ -81,7 +80,7 @@ generic-impls = ["num-traits"]
 bin = ["clap", "poloto", "regression", "binary_search_rng", "ols"]
 
 # Prettier bin output
-pretty = ["bin", "atty", "colored"]
+pretty = ["bin", "colored"]
 
 # Shell completion output
 completion = ["clap_autocomplete"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "std-dev"
 description = "Your Swiss Army knife for swiftly processing any amount of data. Implemented for industrial and educational purposes alike."
 # strip=true in profile below,
 # 1.56 for edition 2021
-rust-version = "1.59"
+rust-version = "1.70"
 version = "0.1.0"
 edition = "2021"
 license = "LGPL-3.0-or-later"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -3,7 +3,7 @@ use std::env;
 use std::fmt::{Debug, Display};
 #[cfg(feature = "regression")]
 use std::io::Write;
-use std::io::{stdin, BufRead};
+use std::io::{stdin, BufRead, IsTerminal};
 use std::process::exit;
 use std::str::FromStr;
 use std::time::Instant;

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -608,7 +608,7 @@ fn main() {
     );
 
     #[cfg(feature = "pretty")]
-    let tty = atty::is(atty::Stream::Stdin);
+    let tty = std::io::stdin().is_terminal();
     #[cfg(not(feature = "pretty"))]
     let tty = false;
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -862,7 +862,7 @@ fn main() {
                         })
                         .unwrap_or(500);
                     if config.get_flag("linear")
-                        || config.get_one::<usize>("degree").map_or(false, |o| *o == 1)
+                        || config.get_one::<usize>("degree").is_some_and(|o| *o == 1)
                     {
                         num_samples = 2;
                     }


### PR DESCRIPTION
This is a fix to PR #39 which I mistakenly create PR without a build test.

This PR fixes:
- Removing atty from the dependency in favor of standard Rust std::io
- Bump rust-version to 1.70
- Simplify `map_or` in favor of `is_some_and` according to Clippy lints suggestion

The codes were tested and passed the build process.